### PR TITLE
(bug)ph_board: Read from conversion register at address 0

### DIFF
--- a/ph_board/channel.go
+++ b/ph_board/channel.go
@@ -41,7 +41,7 @@ func (c *channel) Calibrate(points []hal.Measurement) error {
 
 func (c *channel) Read() (float64, error) {
 	buf := make([]byte, 2)
-	if err := c.bus.ReadFromReg(c.addr, 0x10, buf); err != nil {
+	if err := c.bus.ReadFromReg(c.addr, 0x0, buf); err != nil {
 		return -1, err
 	}
 	v := int16(buf[0])<<8 | int16(buf[1])


### PR DESCRIPTION
The ADS1115 has no register 0x10, so writes to 0x10 are technically in
a reserved bit mask. Based on the documentation, 0x0 is the conversion
register to utilize.