### PR TITLE
fix issue with pca9685 100% output. fixes #18

### DIFF
--- a/hal/pca9685/pca9685.go
+++ b/hal/pca9685/pca9685.go
@@ -139,6 +139,16 @@ func (p *pca9685Driver) set(pin int, value float64) error {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	on := 0
 	off := int(value * 40.95)
-	return p.hwDriver.SetPwm(pin, 0, off)
+	if value == 100 {
+		//Special case for 100% on.  LEDn_ON_H bit 4 will turn on 100%
+		on = 4096
+		off = 0
+	} else if value == 0 {
+		//Special case for 0%.  LEDn_OFF_H bit 4 will turn completely off.
+		off = 4096
+	}
+
+	return p.hwDriver.SetPwm(pin, on, off)
 }


### PR DESCRIPTION
Uses special control bits to set pwm channel to 100% and 0%.

I couldn't see a reasonable way to write a unit test to make sure the pca9685 driver is called with the appropriate values, but I'm definitely open to feedback.  Functionality was manually tested and confirmed on pi 3 hardware.