### PR TITLE
Revert "(bug)ph_board: Read from conversion register at address 0"

### DIFF
--- a/ph_board/channel.go
+++ b/ph_board/channel.go
@@ -41,7 +41,7 @@ func (c *channel) Calibrate(points []hal.Measurement) error {
 
 func (c *channel) Read() (float64, error) {
 	buf := make([]byte, 2)
-	if err := c.bus.ReadFromReg(c.addr, 0x0, buf); err != nil {
+	if err := c.bus.ReadFromReg(c.addr, 0x10, buf); err != nil {
 		return -1, err
 	}
 	v := int16(buf[0])<<8 | int16(buf[1])


### PR DESCRIPTION
This reverts commit 9d7264d460fa1f65aedbc4963196b2cdece2d30d.
@theatrus this is causing the remote i/o error i am experiencing. I just cross checked with the phboard code and with this change reverted they match. 
I'll keep you posted on how it runs for a day.. i'll deploy and start testing