### PR TITLE
WIP: Add an executable stream driver

### DIFF
--- a/execstream/analog.go
+++ b/execstream/analog.go
@@ -1,0 +1,93 @@
+package execstream
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"encoding/json"
+	"github.com/reef-pi/hal"
+	"github.com/reef-pi/rpi/i2c"
+)
+
+type Config struct {
+	Address string `json:"address"`
+}
+
+type analog struct {
+	path       string
+	meta       hal.Metadata
+	calibrator hal.Calibrator
+}
+
+func HalAnalogAdapter(c []byte, _ i2c.Bus) (hal.Driver, error) {
+	var config Config
+	if err := json.Unmarshal(c, &config); err != nil {
+		return nil, err
+	}
+	return NewAnalog(config.Address)
+}
+
+func NewAnalog(p string) (*analog, error) {
+	c, err := hal.CalibratorFactory([]hal.Measurement{})
+	if err != nil {
+		return nil, err
+	}
+	return &analog{
+		path:       p,
+		calibrator: c,
+		meta: hal.Metadata{
+			Name:         "analog-executable-stream",
+			Description:  "A simple file based analog hal driver",
+			Capabilities: []hal.Capability{hal.PH},
+		},
+	}, nil
+}
+
+func (f *analog) Metadata() hal.Metadata {
+	return f.meta
+}
+
+func (f *analog) Close() error {
+	return nil
+}
+
+func (f *analog) Name() string {
+	return f.path
+}
+
+func (f *analog) Read() (float64, error) {
+	data, err := ioutil.ReadFile(f.path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseFloat(strings.TrimSpace(string(data)), 64)
+}
+
+func (f *analog) Measure() (float64, error) {
+	v, err := f.Read()
+	if err != nil {
+		return 0, err
+	}
+	if f.calibrator == nil {
+		return 0, fmt.Errorf("Not calibrated")
+	}
+	return f.calibrator.Calibrate(v), nil
+}
+func (f *analog) Calibrate(points []hal.Measurement) error {
+	cal, err := hal.CalibratorFactory(points)
+	if err != nil {
+		return err
+	}
+	f.calibrator = cal
+	return nil
+}
+
+func (f *analog) ADCChannels() []hal.ADCChannel {
+	return []hal.ADCChannel{f}
+}
+
+func (f *analog) ADCChannel(_ int) (hal.ADCChannel, error) {
+	return f, nil
+}

--- a/execstream/analog_test.go
+++ b/execstream/analog_test.go
@@ -1,0 +1,38 @@
+package execstream
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/reef-pi/hal"
+)
+
+func TestAnalogInput(t *testing.T) {
+	temp, err := ioutil.TempFile("", "hal-file-driver-testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp.Write([]byte("23.1"))
+	temp.Close()
+	defer os.Remove(temp.Name())
+	d, err := NewAnalog(temp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := d.Metadata()
+	if len(meta.Capabilities) != 1 {
+		t.Error("Expected 1 capabilities, found:", len(meta.Capabilities))
+	}
+	dig := hal.ADCDriver(d)
+	if len(dig.ADCChannels()) != 1 {
+		t.Error("Expected a single input pin, found:", len(dig.ADCChannels()))
+	}
+	pin, err := dig.ADCChannel(0)
+	if err != nil {
+		t.Error(err)
+	}
+	if _, err := pin.Read(); err != nil {
+		t.Error(err)
+	}
+}

--- a/execstream/digital.go
+++ b/execstream/digital.go
@@ -1,0 +1,103 @@
+package execstream
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"encoding/json"
+	"github.com/reef-pi/hal"
+	"github.com/reef-pi/rpi/i2c"
+)
+
+type digitalPin struct {
+	pin       int
+	stream    streamSupervisor
+	meta      hal.Metadata
+	lastState bool
+}
+
+type streamSupervisor struct {
+	path string
+	cmd exec.Cmd
+	meta hal.Metadata
+}
+
+func HalDigitalAdapter(c []byte, _ i2c.Bus) (hal.Driver, error) {
+	var config Config
+	if err := json.Unmarshal(c, &config); err != nil {
+		return nil, err
+	}
+	return NewDigital(config.Address), nil
+}
+
+func NewDigital(p string) *streamSupervisor {
+	return &streamSupervisor{
+		path: p,
+		meta: hal.Metadata{
+			Name:         "executable-stream",
+			Description:  "Driver to execute programs for I/O",
+			Capabilities: []hal.Capability{hal.Input, hal.Output, hal.PWM},
+		},
+	}
+}
+
+func (f *streamSupervisor) Metadata() hal.Metadata {
+	return f.meta
+}
+
+func (f *streamSupervisor) Close() error {
+	return nil
+}
+
+func (f *streamSupervisor) Name() string {
+	return f.path
+}
+
+func (f *digitalPin) Read() (bool, error) {
+	data, err := ioutil.ReadFile(f.path)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(data)) == "1", nil
+}
+
+func (f *digitalPin) LastState() bool {
+	return f.lastState
+}
+
+func (f *digitalPin) Write(b bool) error {
+	f.lastState = b
+	if b {
+		return ioutil.WriteFile(f.path, []byte("1"), 0644)
+	}
+	return ioutil.WriteFile(f.path, []byte("0"), 0644)
+
+}
+func (f *digitalPin) Set(v float64) error {
+	return ioutil.WriteFile(f.path, []byte(strconv.FormatFloat(v, 'f', -1, 64)), 0644)
+}
+
+func (f *streamSupervisor) InputPins() []hal.InputPin {
+	return []hal.InputPin{f}
+}
+
+func (f *streamSupervisor) InputPin(_ int) (hal.InputPin, error) {
+	return f, nil
+}
+
+func (f *streamSupervisor) OutputPins() []hal.OutputPin {
+	return []hal.OutputPin{f}
+}
+
+func (f *streamSupervisor) OutputPin(_ int) (hal.OutputPin, error) {
+	return f, nil
+}
+func (f *streamSupervisor) PWMChannels() []hal.PWMChannel {
+	return []hal.PWMChannel{f}
+}
+
+func (f *streamSupervisor) PWMChannel(_ int) (hal.PWMChannel, error) {
+	return f, nil
+}

--- a/execstream/digital_test.go
+++ b/execstream/digital_test.go
@@ -1,0 +1,73 @@
+package execstream
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/reef-pi/hal"
+)
+
+func TestDigitalInput(t *testing.T) {
+	temp, err := ioutil.TempFile("", "hal-file-driver-testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp.Close()
+	defer os.Remove(temp.Name())
+	d := NewDigital(temp.Name())
+	meta := d.Metadata()
+	if len(meta.Capabilities) != 3 {
+		t.Error("Expected 3 capabilities, found:", len(meta.Capabilities))
+	}
+	dig := hal.InputDriver(d)
+	if len(dig.InputPins()) != 1 {
+		t.Error("Expected a single input pin, found:", len(dig.InputPins()))
+	}
+	pin, err := dig.InputPin(0)
+	if err != nil {
+		t.Error(err)
+	}
+	b, err := pin.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	if b {
+		t.Error("Expected false , found true")
+	}
+}
+func TestDigitalOutput(t *testing.T) {
+	temp, err := ioutil.TempFile("", "hal-file-driver-testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp.Close()
+	defer os.Remove(temp.Name())
+	d := NewDigital(temp.Name())
+	dig := hal.OutputDriver(d)
+	pin, err := dig.OutputPin(0)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := pin.Write(true); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPWMOutput(t *testing.T) {
+	temp, err := ioutil.TempFile("", "hal-file-driver-testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp.Close()
+	defer os.Remove(temp.Name())
+	d := NewDigital(temp.Name())
+	dig := hal.PWMDriver(d)
+	pin, err := dig.PWMChannel(0)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := pin.Set(12.3); err != nil {
+		t.Error(err)
+	}
+}

--- a/execstream/types.go
+++ b/execstream/types.go
@@ -1,0 +1,13 @@
+package execstream
+
+type Command struct {
+	Type string `json:"type"`
+	Pin int `json:"pin"`
+	Value *float64 `json:"value,omitempty"`
+}
+
+type Response struct {
+	Type string `json:"type"`
+	Pin int `json:"pin"`
+	Value *float64 `json:"value,omitempty"`
+}


### PR DESCRIPTION
Open a process on the system and perform pin read/write commands over stdin/stdout. Allows other languages to be easily added to the HAL system, e.g. a Python script on the same host. Examples will be provided.

(Code is not yet functional)