### PR TITLE
Fix bug parsing address for ph_board and pico_board

### DIFF
--- a/ph_board/driver_test.go
+++ b/ph_board/driver_test.go
@@ -76,3 +76,21 @@ func TestPhBoardDriver(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestFloatAddress(t *testing.T) {
+	bus := i2c.MockBus()
+	bus.Bytes = make([]byte, 2)
+
+	var floatAddress float64
+	floatAddress = 64
+	var floatparams = map[string]interface{}{
+		"Address": floatAddress,
+	}
+
+	f := Factory()
+	_, err := f.NewDriver(floatparams, bus)
+
+	if err != nil {
+		t.Error("ph_board should convert address to int before casting to byte")
+	}
+}

--- a/ph_board/factory.go
+++ b/ph_board/factory.go
@@ -78,7 +78,8 @@ func (f *phFactory) NewDriver(parameters map[string]interface{}, hardwareResourc
 		return nil, errors.New(hal.ToErrorString(failures))
 	}
 
-	address := byte(parameters[addressParam].(int))
+	intAddress, _ := hal.ConvertToInt(parameters[addressParam])
+	address := byte(intAddress)
 
 	bus := hardwareResources.(i2c.Bus)
 

--- a/pico_board/driver_test.go
+++ b/pico_board/driver_test.go
@@ -64,3 +64,21 @@ func TestPhBoardDriver(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestFloatAddress(t *testing.T) {
+	bus := i2c.MockBus()
+	bus.Bytes = make([]byte, 2)
+
+	var floatAddress float64
+	floatAddress = 72
+	var floatparams = map[string]interface{}{
+		"Address": floatAddress,
+	}
+
+	f := Factory()
+	_, err := f.NewDriver(floatparams, bus)
+
+	if err != nil {
+		t.Error("pico_board should convert address to int before casting to byte")
+	}
+}

--- a/pico_board/factory.go
+++ b/pico_board/factory.go
@@ -78,7 +78,8 @@ func (f *phFactory) NewDriver(parameters map[string]interface{}, hardwareResourc
 		return nil, errors.New(hal.ToErrorString(failures))
 	}
 
-	address := byte(parameters[addressParam].(int))
+	intAddress, _ := hal.ConvertToInt(parameters[addressParam])
+	address := byte(intAddress)
 
 	bus := hardwareResources.(i2c.Bus)
 


### PR DESCRIPTION
Fix the following panic for ph_board and pico_board.  
```
panic: interface conversion: interface {} is float64, not int [recovered]
        panic: interface conversion: interface {} is float64, not int
```

Validation succeeded for the driver and params, but creating the driver did not correctly convert to int using hal.ConvertToInt.  Fixed error in NewDriver methods and added tests to confirm.