### PR TITLE
(feat)Add support for shelly 1 and shelly 2.5 wifi drivers

### DIFF
--- a/shelly/relay.go
+++ b/shelly/relay.go
@@ -1,0 +1,52 @@
+package shelly
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type HTTPGetter func(string) (*http.Response, error)
+
+type Relay struct {
+	channel int
+	addr    string
+	state   bool
+	name    string
+	getter  HTTPGetter
+}
+
+func NewRelay(name, addr string, channel int, getter HTTPGetter) *Relay {
+	r := Relay{
+		channel: channel,
+		addr:    addr,
+		name:    name,
+		getter:  getter,
+	}
+	if getter == nil {
+		h := &http.Client{Timeout: 5 * time.Second}
+		r.getter = h.Get
+	}
+	return &r
+}
+
+func (r *Relay) Close() error    { return nil }
+func (r *Relay) Number() int     { return r.channel }
+func (r *Relay) LastState() bool { return r.state }
+func (r *Relay) Name() string    { return r.name }
+
+func (r *Relay) Write(b bool) error {
+	action := "on"
+	if !b {
+		action = "off"
+	}
+	resp, err := r.getter(fmt.Sprintf("%s/relay/%d?turn=%s", r.addr, r.channel, action))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http failure. Code:%d", resp.StatusCode)
+	}
+	r.state = b
+	return nil
+}

--- a/shelly/shelly.go
+++ b/shelly/shelly.go
@@ -1,0 +1,1 @@
+package shelly

--- a/shelly/shelly1_test.go
+++ b/shelly/shelly1_test.go
@@ -1,0 +1,29 @@
+package shelly
+
+import (
+	"github.com/reef-pi/hal"
+	"testing"
+)
+
+func TestShelly1(t *testing.T) {
+	d, err := NewShelly1("127.0.0.1", true)
+	if err != nil {
+		t.Error(err)
+	}
+	if d.Metadata().Name == "" {
+		t.Error("HAL metadata should not have empty name")
+	}
+
+	d1 := d.(hal.DigitalOutputDriver)
+
+	if len(d1.DigitalOutputPins()) != 1 {
+		t.Error("Expected exactly two output pin")
+	}
+	pin, err := d1.DigitalOutputPin(0)
+	if err != nil {
+		t.Error(err)
+	}
+	if pin.LastState() != false {
+		t.Error("Expected initial state to be false")
+	}
+}

--- a/shelly/shelly1_test.go
+++ b/shelly/shelly1_test.go
@@ -26,4 +26,7 @@ func TestShelly1(t *testing.T) {
 	if pin.LastState() != false {
 		t.Error("Expected initial state to be false")
 	}
+	if err := pin.Write(true); err != nil {
+		t.Error(err)
+	}
 }

--- a/shelly/shelly25.go
+++ b/shelly/shelly25.go
@@ -1,6 +1,7 @@
 package shelly
 
 import (
+	"errors"
 	"fmt"
 	"github.com/reef-pi/hal"
 	"net/http"
@@ -8,7 +9,66 @@ import (
 
 const (
 	_shelly25 = "shelly25"
+	_addr     = "Address"
 )
+
+type Shelly25Factory struct {
+	meta       hal.Metadata
+	parameters []hal.ConfigParameter
+	devMode    bool
+}
+
+func Shelly25Adapter(devMode bool) hal.DriverFactory {
+	return &Shelly25Factory{
+		meta: hal.Metadata{
+			Name:         "Shelly2,5",
+			Description:  "Shelly 2.5 , dual relay wifi driver",
+			Capabilities: []hal.Capability{hal.DigitalOutput},
+		},
+		parameters: []hal.ConfigParameter{
+			{
+				Name:    _addr,
+				Type:    hal.String,
+				Order:   0,
+				Default: "192.168.1.33",
+			},
+		},
+		devMode: devMode,
+	}
+}
+
+func (f *Shelly25Factory) Metadata() hal.Metadata {
+	return f.meta
+}
+func (f *Shelly25Factory) GetParameters() []hal.ConfigParameter {
+	return f.parameters
+}
+
+func (f *Shelly25Factory) ValidateParameters(parameters map[string]interface{}) (bool, map[string][]string) {
+
+	var failures = make(map[string][]string)
+
+	if v, ok := parameters[_addr]; ok {
+		_, ok := v.(string)
+		if !ok {
+			failure := fmt.Sprint(_addr, " is not a string. ", v, " was received.")
+			failures[_addr] = append(failures[_addr], failure)
+		}
+	} else {
+		failure := fmt.Sprint(_addr, " is a required parameter, but was not received.")
+		failures[_addr] = append(failures[_addr], failure)
+	}
+
+	return len(failures) == 0, failures
+}
+
+func (f *Shelly25Factory) NewDriver(params map[string]interface{}, _ interface{}) (hal.Driver, error) {
+	if valid, failures := f.ValidateParameters(params); !valid {
+		return nil, errors.New(hal.ToErrorString(failures))
+	}
+	addr := params[_addr].(string)
+	return NewShelly25(addr, f.devMode)
+}
 
 type Shelly25 struct {
 	meta hal.Metadata

--- a/shelly/shelly25.go
+++ b/shelly/shelly25.go
@@ -1,0 +1,63 @@
+package shelly
+
+import (
+	"fmt"
+	"github.com/reef-pi/hal"
+	"net/http"
+)
+
+const (
+	_shelly25 = "shelly25"
+)
+
+type Shelly25 struct {
+	meta hal.Metadata
+	pins []*Relay
+}
+
+func NewShelly25(a string, devMode bool) (hal.DigitalOutputDriver, error) {
+	addr := "http://" + a
+	var getter HTTPGetter
+	if devMode {
+		getter = func(_ string) (*http.Response, error) {
+			return new(http.Response), nil
+		}
+	}
+
+	return &Shelly25{
+		meta: hal.Metadata{
+			Name:         "Shelly2,5",
+			Description:  "Shelly 2.5 , dual relay wifi driver",
+			Capabilities: []hal.Capability{hal.DigitalOutput},
+		},
+		pins: []*Relay{
+			NewRelay("Shelly 2.5 Relay 0", addr, 0, getter),
+			NewRelay("Shelly 2.5 Relay 1", addr, 1, getter),
+		},
+	}, nil
+}
+
+func (s *Shelly25) Metadata() hal.Metadata {
+	return s.meta
+}
+func (s *Shelly25) Close() error {
+	return nil
+}
+
+func (s *Shelly25) Pins(cap hal.Capability) ([]hal.Pin, error) {
+	switch cap {
+	case hal.DigitalOutput:
+		return []hal.Pin{s.pins[0], s.pins[1]}, nil
+	default:
+		return nil, fmt.Errorf("unspoorted capability")
+	}
+}
+func (s *Shelly25) DigitalOutputPins() []hal.DigitalOutputPin {
+	return []hal.DigitalOutputPin{s.pins[0], s.pins[1]}
+}
+func (s *Shelly25) DigitalOutputPin(pin int) (hal.DigitalOutputPin, error) {
+	if pin == 0 || pin == 1 {
+		return s.pins[pin], nil
+	}
+	return nil, fmt.Errorf("unknown pin:%d", pin)
+}

--- a/shelly/shelly25_test.go
+++ b/shelly/shelly25_test.go
@@ -1,0 +1,29 @@
+package shelly
+
+import (
+	"github.com/reef-pi/hal"
+	"testing"
+)
+
+func TestShelly25(t *testing.T) {
+	d, err := NewShelly25("127.0.0.1", true)
+	if err != nil {
+		t.Error(err)
+	}
+	if d.Metadata().Name == "" {
+		t.Error("HAL metadata should not have empty name")
+	}
+
+	d1 := d.(hal.DigitalOutputDriver)
+
+	if len(d1.DigitalOutputPins()) != 2 {
+		t.Error("Expected exactly two output pin")
+	}
+	pin, err := d1.DigitalOutputPin(0)
+	if err != nil {
+		t.Error(err)
+	}
+	if pin.LastState() != false {
+		t.Error("Expected initial state to be false")
+	}
+}

--- a/shelly/shelly25_test.go
+++ b/shelly/shelly25_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func TestShelly25(t *testing.T) {
-	d, err := NewShelly25("127.0.0.1", true)
+	f := Shelly25Adapter(true)
+	params := make(map[string]interface{})
+	params[_addr] = "127.0.0.1"
+	d, err := f.NewDriver(params, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/shelly/shelly_1.go
+++ b/shelly/shelly_1.go
@@ -1,0 +1,58 @@
+package shelly
+
+import (
+	"fmt"
+	"github.com/reef-pi/hal"
+	"net/http"
+)
+
+type Shelly1 struct {
+	meta hal.Metadata
+	pins []*Relay
+}
+
+func NewShelly1(a string, devMode bool) (hal.DigitalOutputDriver, error) {
+	addr := "http://" + a
+	var getter HTTPGetter
+	if devMode {
+		getter = func(_ string) (*http.Response, error) {
+			return new(http.Response), nil
+		}
+	}
+
+	return &Shelly1{
+		meta: hal.Metadata{
+			Name:         "Shelly1",
+			Description:  "Shelly 1, single relay wifi driver",
+			Capabilities: []hal.Capability{hal.DigitalOutput},
+		},
+		pins: []*Relay{
+			NewRelay("Shelly One Relay 0", addr, 0, getter),
+		},
+	}, nil
+}
+
+func (s *Shelly1) Metadata() hal.Metadata {
+	return s.meta
+}
+func (s *Shelly1) Close() error {
+	return nil
+}
+
+func (s *Shelly1) Pins(cap hal.Capability) ([]hal.Pin, error) {
+	switch cap {
+	case hal.DigitalOutput:
+		return []hal.Pin{s.pins[0]}, nil
+	default:
+		return nil, fmt.Errorf("unspoorted capability")
+	}
+}
+func (s *Shelly1) DigitalOutputPins() []hal.DigitalOutputPin {
+	return []hal.DigitalOutputPin{s.pins[0]}
+}
+func (s *Shelly1) DigitalOutputPin(pin int) (hal.DigitalOutputPin, error) {
+	if pin == 0 {
+		return s.pins[pin], nil
+	}
+	return nil, fmt.Errorf("unknown pin:%d", pin)
+}

--- a/shelly/shelly_1.go
+++ b/shelly/shelly_1.go
@@ -17,7 +17,9 @@ func NewShelly1(a string, devMode bool) (hal.DigitalOutputDriver, error) {
 	var getter HTTPGetter
 	if devMode {
 		getter = func(_ string) (*http.Response, error) {
-			return new(http.Response), nil
+			resp := new(http.Response)
+			resp.StatusCode = http.StatusOK
+			return resp, nil
 		}
 	}
 

--- a/tplink/hs103.go
+++ b/tplink/hs103.go
@@ -171,7 +171,7 @@ func (f *hs103Factory) ValidateParameters(parameters map[string]interface{}) (bo
 	return len(failures) == 0, failures
 }
 
-func (f *hs103Factory) NewDriver(parameters map[string]interface{}, hardwareResources interface{}) (hal.Driver, error) {
+func (f *hs103Factory) NewDriver(parameters map[string]interface{}, _ interface{}) (hal.Driver, error) {
 	if valid, failures := f.ValidateParameters(parameters); !valid {
 		return nil, errors.New(hal.ToErrorString(failures))
 	}

--- a/tplink/hs103_test.go
+++ b/tplink/hs103_test.go
@@ -1,9 +1,8 @@
 package tplink
 
 import (
-	"testing"
-
 	"github.com/reef-pi/hal"
+	"testing"
 )
 
 func TestHS103Plug(t *testing.T) {


### PR DESCRIPTION
- Initial support for shelly 1 and 2.5 wifi drivers. with only digital output capabilities.
