### PR TITLE
Tasmota HTTP driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage.txt
 vendor
 .vscode/*
+.idea

--- a/tasmota/http.go
+++ b/tasmota/http.go
@@ -1,0 +1,188 @@
+package tasmota
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/reef-pi/hal"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type httpDriver struct {
+	meta    hal.Metadata
+	address string
+}
+
+func (m *httpDriver) Close() error {
+	return nil
+}
+
+func (m *httpDriver) Metadata() hal.Metadata {
+	return m.meta
+}
+
+func (m *httpDriver) Name() string {
+	return "Tasmota"
+}
+
+func (m *httpDriver) Number() int {
+	return 0
+}
+
+func (m *httpDriver) Pins(capability hal.Capability) ([]hal.Pin, error) {
+	switch capability {
+	case hal.PWM:
+		return []hal.Pin{m}, nil
+	default:
+		return nil, fmt.Errorf("unsupported capability:%s", capability.String())
+	}
+}
+
+func (m *httpDriver) PWMChannels() []hal.PWMChannel {
+	return []hal.PWMChannel{m}
+}
+
+func (m *httpDriver) PWMChannel(_ int) (hal.PWMChannel, error) {
+	return m, nil
+}
+
+
+func (m *httpDriver) LastState() bool {
+	uri := fmt.Sprintf("http://%s/cm?cmnd=Power0", m.address)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		log.Println(err.Error())
+		return false
+	}
+	c := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Println(err.Error())
+		return false
+	}
+	defer resp.Body.Close()
+	msg, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		log.Println("Tasmota: URI: ", req.URL.String(), " Http Code: ", resp.StatusCode, "Channel:", string(msg))
+		return false
+	}
+	var result map[string]interface{}
+	err = json.Unmarshal([]byte(msg), &result)
+	if err != nil {
+		return false
+	}
+	return result["POWER"] == "ON"
+}
+
+func (m *httpDriver) Set(value float64) error {
+	uri := fmt.Sprintf("http://%s/cm?cmnd=Dimmer%%20%.0f", m.address, value)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return err
+	}
+	c := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	msg, _ := ioutil.ReadAll(resp.Body)
+	log.Println("Tasmota: URI: ", req.URL.String(), " Http Code: ", resp.StatusCode, "Channel:", string(msg))
+	if resp.StatusCode == 200 {
+		return nil
+	}
+	return fmt.Errorf("HTTP Code:%d. Body:%v", resp.StatusCode, string(msg))
+}
+
+func (m *httpDriver) Write(b bool) error {
+	uri := fmt.Sprintf("http://%s/cm?cmnd=Power0%%20%t", m.address, b)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return err
+	}
+	c := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	msg, _ := ioutil.ReadAll(resp.Body)
+	log.Println("Tasmota: URI: ", req.URL.String(), " Http Code: ", resp.StatusCode, "Channel:", string(msg))
+	if resp.StatusCode == 200 {
+		return nil
+	}
+	return fmt.Errorf("HTTP Code:%d. Body:%v", resp.StatusCode, string(msg))
+}
+
+func (m *httpDriver) DigitalOutputPins() []hal.DigitalOutputPin {
+	return []hal.DigitalOutputPin{m}
+}
+
+func (m *httpDriver) DigitalOutputPin(_ int) (hal.DigitalOutputPin, error) {
+	return m, nil
+}
+
+type factory struct {
+	meta       hal.Metadata
+	parameters []hal.ConfigParameter
+}
+
+var pwmDriverFactory *factory
+var once sync.Once
+
+func HttpDriverFactory() hal.DriverFactory {
+
+	once.Do(func() {
+		pwmDriverFactory = &factory{
+			meta: hal.Metadata{
+				Name:         "Tasmota Http",
+				Description:  "Tasmota Http Driver",
+				Capabilities: []hal.Capability{hal.PWM, hal.DigitalOutput},
+			},
+			parameters: []hal.ConfigParameter{
+				{
+					Name:    "Domain or Address",
+					Type:    hal.String,
+					Order:   0,
+					Default: "192.1.168.4",
+				},
+			},
+		}
+	})
+
+	return pwmDriverFactory
+}
+
+func (f *factory) GetParameters() []hal.ConfigParameter {
+	return f.parameters
+}
+
+func (f *factory) ValidateParameters(parameters map[string]interface{}) (bool, map[string][]string) {
+	var failures = make(map[string][]string)
+	return true, failures
+}
+
+func (f *factory) Metadata() hal.Metadata {
+	return f.meta
+}
+
+func (f *factory) NewDriver(parameters map[string]interface{}, hardwareResources interface{}) (hal.Driver, error) {
+	if valid, failures := f.ValidateParameters(parameters); !valid {
+		return nil, errors.New(hal.ToErrorString(failures))
+	}
+	driver := &httpDriver{
+		meta: f.meta,
+		address: parameters["Domain Or Address"].(string),
+	}
+	return driver, nil
+}

--- a/tasmota/http_test.go
+++ b/tasmota/http_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-func TestHttpDriver(t *testing.T) {
+func TestHttpDriver_AsDigitalOut(t *testing.T) {
 
 	f := HttpDriverFactory()
 
 	params := map[string]interface{}{
-		"Domain Or Address": "192.168.1.46",
+		"Domain or Address": "192.168.1.46",
 	}
 
 	d, err := f.NewDriver(params, nil)
@@ -37,6 +37,26 @@ func TestHttpDriver(t *testing.T) {
 		t.Error("Expected a digital output pin")
 	}
 
+}
+
+func TestHttpDriver_AsPWMDriver(t *testing.T) {
+
+	f := HttpDriverFactory()
+
+	params := map[string]interface{}{
+		"Domain or Address": "192.168.1.46",
+	}
+
+	d, err := f.NewDriver(params, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	meta := d.Metadata()
+	if len(meta.Capabilities) != 2 {
+		t.Error("Expected 1 capabilities, found:", len(meta.Capabilities))
+	}
+
 	pwm, ok := d.(hal.PWMDriver)
 	if !ok {
 		t.Error("Failed to type driver to PWM driver")
@@ -49,6 +69,48 @@ func TestHttpDriver(t *testing.T) {
 	_, err = pwm.PWMChannel(0)
 	if err != nil {
 		t.Error("Expected a pwm pin")
+	}
+
+}
+
+func TestHttpDriver_FactoryValidateParameters(t *testing.T) {
+
+	f := HttpDriverFactory()
+
+	params := map[string]interface{}{
+		"Domain or Address": "192.168.1.46",
+	}
+
+	_, err := f.NewDriver(params, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params = map[string]interface{}{
+		"Domain or Address": "",
+	}
+
+	_, err = f.NewDriver(params, nil)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+
+	params = map[string]interface{}{
+		"Domain or Address": 1,
+	}
+
+	_, err = f.NewDriver(params, nil)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+
+	params = map[string]interface{}{
+		"Domain or Address": nil,
+	}
+
+	_, err = f.NewDriver(params, nil)
+	if err == nil {
+		t.Fatal("Expected error")
 	}
 
 }

--- a/tasmota/http_test.go
+++ b/tasmota/http_test.go
@@ -1,0 +1,54 @@
+package tasmota
+
+import (
+	"github.com/reef-pi/hal"
+	"testing"
+)
+
+func TestHttpDriver(t *testing.T) {
+
+	f := HttpDriverFactory()
+
+	params := map[string]interface{}{
+		"Domain Or Address": "192.168.1.46",
+	}
+
+	d, err := f.NewDriver(params, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	meta := d.Metadata()
+	if len(meta.Capabilities) != 2 {
+		t.Error("Expected 1 capabilities, found:", len(meta.Capabilities))
+	}
+
+	o, ok := d.(hal.DigitalOutputDriver)
+	if !ok {
+		t.Error("Failed to type driver to Digital output driver")
+	}
+
+	if len(o.DigitalOutputPins()) != 1 {
+		t.Error("Expected a single digital output pwm pin, found:", len(o.DigitalOutputPins()))
+	}
+
+	_, err = o.DigitalOutputPin(0)
+	if err != nil {
+		t.Error("Expected a digital output pin")
+	}
+
+	pwm, ok := d.(hal.PWMDriver)
+	if !ok {
+		t.Error("Failed to type driver to PWM driver")
+	}
+
+	if len(pwm.PWMChannels()) != 1 {
+		t.Error("Expected a single pwm channel, found:", len(pwm.PWMChannels()))
+	}
+
+	_, err = pwm.PWMChannel(0)
+	if err != nil {
+		t.Error("Expected a pwm pin")
+	}
+
+}

--- a/tasmota/http_test.go
+++ b/tasmota/http_test.go
@@ -2,15 +2,22 @@ package tasmota
 
 import (
 	"github.com/reef-pi/hal"
+	"os"
 	"testing"
 )
 
 func TestHttpDriver_AsDigitalOut(t *testing.T) {
 
+	address := os.Getenv("TASMOTA_TEST_ADDRESS")
+
+	if 	len(address) == 0 {
+		address = "192.168.1.46"
+	}
+
 	f := HttpDriverFactory()
 
 	params := map[string]interface{}{
-		"Domain or Address": "192.168.1.46",
+		"Domain or Address": address,
 	}
 
 	d, err := f.NewDriver(params, nil)
@@ -32,19 +39,56 @@ func TestHttpDriver_AsDigitalOut(t *testing.T) {
 		t.Error("Expected a single digital output pwm pin, found:", len(o.DigitalOutputPins()))
 	}
 
-	_, err = o.DigitalOutputPin(0)
-	if err != nil {
+	p, err := o.DigitalOutputPin(0)
+	if err != nil || p == nil {
 		t.Error("Expected a digital output pin")
+	}
+
+	if p.Name() != "Tasmota" {
+		t.Error("Expected Tasmota name, found: ", p.Name())
+	}
+
+	if p.Number() != 0 {
+		t.Error("Expected number 0, found: ", p.Number())
+	}
+
+	testRealDevice := os.Getenv("TASMOTA_TEST_REAL_DEVICE")
+
+	if testRealDevice == "True" {
+
+		err = p.Write(true)
+		if err != nil {
+			t.Error("Expected write true inn the digital output, error: ", err.Error())
+		}
+
+		if !p.LastState() {
+			t.Error("Expected last state is true")
+		}
+
+		err = p.Write(false)
+		if err != nil {
+			t.Error("Expected write false inn the digital output, error: ", err.Error())
+		}
+
+		if p.LastState() {
+			t.Error("Expected last state is false")
+		}
 	}
 
 }
 
 func TestHttpDriver_AsPWMDriver(t *testing.T) {
 
+	address := os.Getenv("TASMOTA_TEST_ADDRESS")
+
+	if 	len(address) == 0 {
+		address = "192.168.1.46"
+	}
+
 	f := HttpDriverFactory()
 
 	params := map[string]interface{}{
-		"Domain or Address": "192.168.1.46",
+		"Domain or Address": address,
 	}
 
 	d, err := f.NewDriver(params, nil)


### PR DESCRIPTION
Add initial support to [Tasmota](https://tasmota.github.io/docs/) devices with using a http driver.

Relates to https://github.com/reef-pi/reef-pi/issues/1273

Used and tested in a planted tank to control lights using a led controller device and to control temperature using a plug device.