### PR TITLE
Fix Tasmota driver creation

### DIFF
--- a/tasmota/http.go
+++ b/tasmota/http.go
@@ -146,7 +146,7 @@ type factory struct {
 var pwmDriverFactory *factory
 var once sync.Once
 
-const address = "Domain or Address"
+const address = "Address"
 
 func HttpDriverFactory() hal.DriverFactory {
 

--- a/tasmota/http_test.go
+++ b/tasmota/http_test.go
@@ -17,7 +17,7 @@ func TestHttpDriver_AsDigitalOut(t *testing.T) {
 	f := HttpDriverFactory()
 
 	params := map[string]interface{}{
-		"Domain or Address": address,
+		"Address": address,
 	}
 
 	d, err := f.NewDriver(params, nil)
@@ -88,7 +88,7 @@ func TestHttpDriver_AsPWMDriver(t *testing.T) {
 	f := HttpDriverFactory()
 
 	params := map[string]interface{}{
-		"Domain or Address": address,
+		"Address": address,
 	}
 
 	d, err := f.NewDriver(params, nil)
@@ -153,7 +153,7 @@ func TestHttpDriver_FactoryValidateParameters(t *testing.T) {
 	f := HttpDriverFactory()
 
 	params := map[string]interface{}{
-		"Domain or Address": "192.168.1.46",
+		"Address": "192.168.1.46",
 	}
 
 	_, err := f.NewDriver(params, nil)
@@ -162,7 +162,7 @@ func TestHttpDriver_FactoryValidateParameters(t *testing.T) {
 	}
 
 	params = map[string]interface{}{
-		"Domain or Address": "",
+		"Address": "",
 	}
 
 	_, err = f.NewDriver(params, nil)
@@ -171,7 +171,7 @@ func TestHttpDriver_FactoryValidateParameters(t *testing.T) {
 	}
 
 	params = map[string]interface{}{
-		"Domain or Address": 1,
+		"Address": 1,
 	}
 
 	_, err = f.NewDriver(params, nil)
@@ -180,7 +180,7 @@ func TestHttpDriver_FactoryValidateParameters(t *testing.T) {
 	}
 
 	params = map[string]interface{}{
-		"Domain or Address": nil,
+		"Address": nil,
 	}
 
 	_, err = f.NewDriver(params, nil)


### PR DESCRIPTION
Change Tasmota driver config key `Domain or Address` to `Address`.

If `Domain or Address` is used as a key and it is defined as a constant, driver factory fails on parameters validation.

